### PR TITLE
AUTO-630 Update sensor status more frequently then once.

### DIFF
--- a/include/urg_node2/urg_node2.hpp
+++ b/include/urg_node2/urg_node2.hpp
@@ -58,6 +58,7 @@ using namespace std::chrono_literals;
 
 namespace urg_node2
 {
+static const std::string SENSOR_OK = "Sensor works well.";
 
 class UrgNode2 : public rclcpp_lifecycle::LifecycleNode
 {
@@ -325,6 +326,8 @@ private:
   int skip_;
   /** パラメータ"cluster" : グルーピング設定 */
   int cluster_;
+  /** how long between reading the sensor status */
+  double status_update_delay_;
 
   /** デバイス状態 : urg_sensor_status()の値を格納 */
   std::string device_status_;


### PR DESCRIPTION
[JIRA-LINK](https://dexory.atlassian.net/browse/AUTO-630)

This PR modifies the urg_node2 to update the sensor_status and is_stable state more frequently that on start (and in error). There is now a ROS2 parameter ***status_update_delay*** which determines how frequently this is updated. It takes a long time to update ~28 milliseconds so if done too frequently it will slow the publish rate of the sensor. I've added a limit to the parameter to prevent it from being set too low and breaking the driver.

This now means the sensor status updates while the driver is running allowing us to at least detect when the sensor is unhappy. To test launch the driver and

```
ros2 topic echo /diagnostics
```

If all is well the following diagnostic status will be published:

---
header:
  stamp:
    sec: 1678380008
    nanosec: 466729752
  frame_id: ''
status:
**- level: "\0"**
  name: 'urg_node2_back_right_node: Hardware Status'
  message: Streaming
  hardware_id: L2206655
  values:
  - key: IP Address
    value: 172.16.0.14
  - key: IP Port
    value: '10940'
  - key: Product Name
    value: UAM-05LP
  - key: Firmware Version
    value: 02.04.01r
  - key: Device ID
    value: L2206655
  - key: Computed Latency
    value: '0'
  - key: User Time Offset
    value: '-0.003'
  **- key: Device Status
    value: Sensor works well.**
  - key: Sensor Status
    value: Measuring by Sensitive Mode
  - key: Scan Retrieve Error Count
    value: '0'
  - key: Scan Retrieve Total Error Count
    value: '0'
  - key: Reconnection Count
    value: '0'

If there is a problem e.g. dirt you will get:

---
header:
  stamp:
    sec: 1678380100
    nanosec: 466712323
  frame_id: ''
status:
**- level: "\x02"**
  name: 'urg_node2_back_right_node: Hardware Status'
  message: 'Abnormal status: Sensor is in error state.'
  hardware_id: L2206655
  values:
  - key: IP Address
    value: 172.16.0.14
  - key: IP Port
    value: '10940'
  - key: Product Name
    value: UAM-05LP
  - key: Firmware Version
    value: 02.04.01r
  - key: Device ID
    value: L2206655
  - key: Computed Latency
    value: '0'
  - key: User Time Offset
    value: '-0.003'
  **- key: Device Status
    value: Sensor is in error state.**
  - key: Sensor Status
    value: Measuring by Sensitive Mode
  - key: Scan Retrieve Error Count
    value: '0'
  - key: Scan Retrieve Total Error Count
    value: '0'
  - key: Reconnection Count
    value: '0'
